### PR TITLE
makefile: set deb architecture dynamically

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,5 +4,7 @@ GoveeBTTempLogger/usr/local/bin/goveebttemplogger: goveebttemplogger.cpp
 	g++ -Wno-psabi -O3 -std=c++11 goveebttemplogger.cpp -o GoveeBTTempLogger/usr/local/bin/goveebttemplogger -lbluetooth
 
 deb: GoveeBTTempLogger/usr/local/bin/goveebttemplogger GoveeBTTempLogger/DEBIAN/control GoveeBTTempLogger/usr/local/lib/systemd/system/goveebttemplogger.service
+	# Set architecture for the resulting .deb to the actually built architecture
+	sed -i "s/Architecture: .*/Architecture: $(shell dpkg --print-architecture)/" GoveeBTTempLogger/DEBIAN/control
 	chmod a+x GoveeBTTempLogger/DEBIAN/postinst GoveeBTTempLogger/DEBIAN/postrm GoveeBTTempLogger/DEBIAN/prerm
 	dpkg-deb --build GoveeBTTempLogger


### PR DESCRIPTION
Looking at
https://unix.stackexchange.com/questions/303434/how-to-specify-deb-package-is-platform-specific-but-for-any-platform
the "correct" way would be to set the architecture to "any"
and then let dpkg-gencontrol set it to the right value.

This looks very complicated for a simple package.

Instead, just set it dynamically to the right
value using sed.

Tested on amd64 and arm64.

Fixes https://github.com/wcbonner/GoveeBTTempLogger/issues/16