### PR TITLE
Added basic build test and flawfinder scan in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+---
+name: CI
+
+on:
+  - push
+
+jobs:
+  Build:
+    name: Build (ubuntu-${{ matrix.image_tag }}) (${{ matrix.compiler }})
+
+    runs-on: ubuntu-${{ matrix.image_tag }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image_tag:
+          - 18.04
+          - 20.04
+          - 22.04
+        compiler:
+          - GNU
+          - LLVM
+
+    env:
+      CXX: ${{ matrix.compiler == 'LLVM' && 'clang++' || 'g++' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install \
+            libbluetooth-dev \
+            make \
+            ${{ matrix.compiler == 'LLVM' && 'clang' || 'g++ gcc' }}
+
+      - name: Build
+        run: |
+          make
+
+      - name: Make & Install `deb` file
+        run: |
+          make deb && sudo make install-deb
+
+      - name: Run `goveebttemplogger --help`
+        run: |
+          goveebttemplogger --help
+
+      - name: Upload `deb` file
+        uses: actions/upload-artifact@v3
+        with:
+          name: ubuntu-${{ matrix.image_tag }} ${{ matrix.compiler }}
+          path: GoveeBTTempLogger.deb

--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -1,0 +1,29 @@
+---
+name: Flawfinder
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  Flawfinder:
+    name: Flawfinder
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run flawfinder
+        uses: david-a-wheeler/flawfinder@2.0.19
+        with:
+          arguments: --sarif goveebttemplogger.cpp
+          output: flawfinder_results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          category: Flawfinder
+          sarif_file: flawfinder_results.sarif

--- a/makefile
+++ b/makefile
@@ -1,7 +1,8 @@
+CXX ?= g++
 
 GoveeBTTempLogger/usr/local/bin/goveebttemplogger: goveebttemplogger.cpp
-	mkdir -p GoveeBTTempLogger/usr/local/bin
-	g++ -Wno-psabi -O3 -std=c++11 goveebttemplogger.cpp -o GoveeBTTempLogger/usr/local/bin/goveebttemplogger -lbluetooth
+	mkdir -p $(shell dirname $@)
+	$(CXX) -Wno-psabi -O3 -std=c++11 $? -o$@ -lbluetooth
 
 deb: GoveeBTTempLogger/usr/local/bin/goveebttemplogger GoveeBTTempLogger/DEBIAN/control GoveeBTTempLogger/usr/local/lib/systemd/system/goveebttemplogger.service
 	# Set architecture for the resulting .deb to the actually built architecture


### PR DESCRIPTION
This ensures the project binary & package will build and install successfully as well as ensuring the application runs and at least displays the help output. The produced `deb` packages will be uploaded as artifacts. Flawfinder runs help identify potential security flaws.

Also added:
* Support for building with `clang++`

Here's an example of a workflow run:
https://github.com/hummeltech/GoveeBTTempLogger/actions/runs/2526496815