### PR TITLE
Remove Ubuntu 18.04 from GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         image_tag:
-          - 18.04
           - 20.04
           - 22.04
         compiler:


### PR DESCRIPTION
It will be fully unsupported by 2023.04.01