### PR TITLE
Runas goveebttemplogger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (POLICY CMP0115)
 endif()
 
 project (GoveeBTTempLogger
-    VERSION 3.20240925.1
+    VERSION 3.20240925.8
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )
@@ -55,7 +55,7 @@ if (CMAKE_VERSION VERSION_GREATER 3.12)
 endif()
 
 target_include_directories(goveebttemplogger PUBLIC
-    "${PROJECT_BINARY_DIR}" 
+    "${PROJECT_BINARY_DIR}"
     ${EXTRA_INCLUDES}
     ${dbus_INCLUDE_DIRS}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (POLICY CMP0115)
 endif()
 
 project (GoveeBTTempLogger
-    VERSION 3.20240925.0
+    VERSION 3.20240925.1
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )
@@ -108,7 +108,6 @@ set(CPACK_DEBIAN_PACKAGE_MAINTAINER "William C Bonner <${CPACK_PACKAGE_CONTACT}>
 include(InstallRequiredSystemLibraries)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
-# set(CPACK_DEBIAN_PACKAGE_RELEASE ${CMAKE_PROJECT_VERSION_PATCH})
 set(CPACK_DEBIAN_PACKAGE_SECTION custom)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/postinst" "${CMAKE_CURRENT_SOURCE_DIR}/prerm" "${CMAKE_CURRENT_SOURCE_DIR}/postrm")
 set(CPACK_STRIP_FILES YES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (POLICY CMP0115)
 endif()
 
 project (GoveeBTTempLogger
-    VERSION 3.20240925.9
+    VERSION 3.20241000.0
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (POLICY CMP0115)
 endif()
 
 project (GoveeBTTempLogger
-    VERSION 3.20241000.0
+    VERSION 3.20241001.0
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (POLICY CMP0115)
 endif()
 
 project (GoveeBTTempLogger
-    VERSION 3.20240925.8
+    VERSION 3.20240925.9
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )

--- a/goveebttemplogger.cpp
+++ b/goveebttemplogger.cpp
@@ -1146,7 +1146,8 @@ std::filesystem::path GenerateLogFileName(const bdaddr_t &a, time_t timer = 0)
 	//OutputFilename << "gvh507x_";
 	//OutputFilename << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << int(a.b[1]);
 	//OutputFilename << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << int(a.b[0]);
-	OutputFilename << "gvh507x_";
+	// The New Format Log File Name includes the entire Bluetooth Address, making it much easier to recognize and add to MRTG config files.
+	OutputFilename << "gvh-";
 	std::string btAddress(ba2string(a));
 	for (auto pos = btAddress.find(':'); pos != std::string::npos; pos = btAddress.find(':'))
 		btAddress.erase(pos, 1);
@@ -1158,34 +1159,7 @@ std::filesystem::path GenerateLogFileName(const bdaddr_t &a, time_t timer = 0)
 		if (!((UTC.tm_year == 70) && (UTC.tm_mon == 0) && (UTC.tm_mday == 1)))
 			OutputFilename << "-" << std::dec << UTC.tm_year + 1900 << "-" << std::setw(2) << std::setfill('0') << UTC.tm_mon + 1;
 	OutputFilename << ".txt";
-	std::filesystem::path OldFormatFileName(LogDirectory / OutputFilename.str());
-
-	// The New Format Log File Name includes the entire Bluetooth Address, making it much easier to recognize and add to MRTG config files.
-	OutputFilename.str("");
-	OutputFilename << "gvh-";
-	OutputFilename << btAddress;
-	if (!((UTC.tm_year == 70) && (UTC.tm_mon == 0) && (UTC.tm_mday == 1)))
-		OutputFilename << "-" << std::dec << UTC.tm_year + 1900 << "-" << std::setw(2) << std::setfill('0') << UTC.tm_mon + 1;
-	OutputFilename << ".txt";
 	std::filesystem::path NewFormatFileName(LogDirectory / OutputFilename.str());
-
-	// This is a temporary hack to transparently change log file name formats
-	std::ifstream OldFile(OldFormatFileName);
-	if (OldFile.is_open())
-	{
-		OldFile.close();
-		try 
-		{ 
-			std::filesystem::rename(OldFormatFileName, NewFormatFileName);
-			std::cerr << "[                   ] Renamed " << OldFormatFileName << " to " << NewFormatFileName << std::endl;
-		}
-		catch (const std::filesystem::filesystem_error& ia)
-		{ 
-			std::cerr << "[                   ] " << ia.what() << std::endl;
-			std::cerr << "[                   ] Unable to Rename " << OldFormatFileName << " to " << NewFormatFileName << std::endl;
-		}
-	}
-
 	return(NewFormatFileName);
 }
 bool GenerateLogFile(std::map<bdaddr_t, std::queue<Govee_Temp>> &AddressTemperatureMap, std::map<bdaddr_t, time_t> &PersistenceData)

--- a/goveebttemplogger.service
+++ b/goveebttemplogger.service
@@ -1,10 +1,20 @@
 # Contents of /etc/systemd/system/goveebttemplogger.service
+
 [Unit]
 Description=GoveeBTTempLogger service
 After=bluetooth.target dbus-org.bluez.service network-online.target
 Requires=bluetooth.target
 StartLimitBurst=5
 StartLimitIntervalSec=33
+
+# The user and directories are created by the postinst script with the following commands:
+# adduser --system --ingroup www-data goveebttemplogger
+# mkdir --verbose --mode 0775 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# chmod --recursive 0664 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# chmod 0775 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+#
+# They are run as root during the installation of the service. The service runs as the newly crteated user.
 
 [Service]
 Type=simple

--- a/goveebttemplogger.service
+++ b/goveebttemplogger.service
@@ -10,9 +10,8 @@ StartLimitIntervalSec=33
 Type=simple
 Restart=always
 RestartSec=30
-ExecStartPre=/bin/mkdir --parents /var/log/goveebttemplogger
-ExecStartPre=/bin/mkdir --parents /var/www/html/goveebttemplogger
-ExecStartPre=/bin/mkdir --parents /var/cache/goveebttemplogger
+User=goveebttemplogger
+Group=www-data
 ExecStart=/usr/local/bin/goveebttemplogger \
     --verbose 0 \
     --log /var/log/goveebttemplogger \

--- a/goveebttemplogger.service
+++ b/goveebttemplogger.service
@@ -9,10 +9,9 @@ StartLimitIntervalSec=33
 
 # The user and directories are created by the postinst script with the following commands:
 # adduser --system --ingroup www-data goveebttemplogger
-# mkdir --verbose --mode 0775 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-# chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-# chmod --recursive 0664 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-# chmod 0775 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# chown --changes --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+# chmod --changes --recursive 0644 /var/log/goveebttemplogger/* /var/cache/goveebttemplogger/* /var/www/html/goveebttemplogger/*
 #
 # They are run as root during the installation of the service. The service runs as the newly crteated user.
 

--- a/postinst
+++ b/postinst
@@ -3,10 +3,10 @@
 
 echo "\033[36m HI I'M A POSTINST SCRIPT `date --rfc-3339='seconds'` running as \033[91m`whoami`\033[39m"
 adduser --system --ingroup www-data goveebttemplogger
-mkdir --mode 0775 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-chmod --recursive 0664 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
-chmod 0775 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+chown --changes --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+chmod --changes --recursive 0644 /var/log/goveebttemplogger/* /var/cache/goveebttemplogger/* /var/www/html/goveebttemplogger/*
+# chmod 0755 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/bin/goveebttemplogger
 systemctl daemon-reload
 systemctl enable goveebttemplogger.service

--- a/postinst
+++ b/postinst
@@ -1,7 +1,13 @@
 #!/bin/sh
 # POSTINST script for goveebttemplogger
 
-echo "\033[36m HI I'M A POSTINST SCRIPT `date +"%s"` \033[39m"
+echo "\033[36m HI I'M A POSTINST SCRIPT `date --rfc-3339='seconds'` running as \033[91m`whoami`\033[39m"
+adduser --system --ingroup www-data goveebttemplogger
+mkdir --mode 0775 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+chmod --recursive 0664 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+chmod 0775 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
+sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/bin/goveebttemplogger
 systemctl daemon-reload
 systemctl enable goveebttemplogger.service
 systemctl start goveebttemplogger.service

--- a/postinst
+++ b/postinst
@@ -1,13 +1,20 @@
 #!/bin/sh
 # POSTINST script for goveebttemplogger
 
+#simple function to deal with multiple files existing and glob
+exists() {
+    [ -e "$1" ]
+}
+
 echo "\033[36m HI I'M A POSTINST SCRIPT `date --rfc-3339='seconds'` running as \033[91m`whoami`\033[39m"
 adduser --system --ingroup www-data goveebttemplogger
 mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 chown --changes --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 chmod --changes --recursive 0644 /var/log/goveebttemplogger/* /var/cache/goveebttemplogger/* /var/www/html/goveebttemplogger/*
 sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/bin/goveebttemplogger
-if [ -f /var/log/goveebttemplogger/gvh507x_*.txt ]; then
+# the next line doesn't handle multiple files existing, I created the function above that handles multiple files
+# if [ -f /var/log/goveebttemplogger/gvh507x_*.txt ]; then
+if exists /var/log/goveebttemplogger/gvh507x_*.txt; then
     mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger/backup
     /usr/local/bin/gvh-organizelogs --log /var/log/goveebttemplogger/ --backup /var/log/goveebttemplogger/backup/
     chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger

--- a/postinst
+++ b/postinst
@@ -7,6 +7,11 @@ mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger /var/cache/gove
 chown --changes --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 chmod --changes --recursive 0644 /var/log/goveebttemplogger/* /var/cache/goveebttemplogger/* /var/www/html/goveebttemplogger/*
 sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/bin/goveebttemplogger
+if [ -f /var/log/goveebttemplogger/gvh507x_*.txt ]; then
+    mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger/backup
+    /usr/local/bin/gvh-organizelogs --log /var/log/goveebttemplogger/ --backup /var/log/goveebttemplogger/backup/
+    chown --recursive goveebttemplogger:www-data /var/log/goveebttemplogger
+fi
 systemctl daemon-reload
 systemctl enable goveebttemplogger.service
 systemctl start goveebttemplogger.service

--- a/postinst
+++ b/postinst
@@ -6,7 +6,6 @@ adduser --system --ingroup www-data goveebttemplogger
 mkdir --verbose --mode 0755 --parents /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 chown --changes --recursive goveebttemplogger:www-data /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 chmod --changes --recursive 0644 /var/log/goveebttemplogger/* /var/cache/goveebttemplogger/* /var/www/html/goveebttemplogger/*
-# chmod 0755 /var/log/goveebttemplogger /var/cache/goveebttemplogger /var/www/html/goveebttemplogger
 sudo setcap 'cap_net_raw,cap_net_admin+eip' /usr/local/bin/goveebttemplogger
 systemctl daemon-reload
 systemctl enable goveebttemplogger.service

--- a/postrm
+++ b/postrm
@@ -1,7 +1,7 @@
 #!/bin/sh
 # POSTRM script for goveebttemplogger
 
-echo "\033[36m HI I'M A POSTRM SCRIPT `date +"%s"` \033[39m"
+echo "\033[36m HI I'M A POSTRM SCRIPT `date --rfc-3339='seconds'` running as \033[91m`whoami`\033[39m"
 systemctl daemon-reload
 
 exit 0

--- a/prerm
+++ b/prerm
@@ -1,7 +1,7 @@
 #!/bin/sh
 # PRERM script for goveebttemplogger
 
-echo "\033[36m HI I'M A PRERM SCRIPT `date +"%s"` \033[39m"
+echo "\033[36m HI I'M A PRERM SCRIPT `date --rfc-3339='seconds'` running as \033[91m`whoami`\033[39m"
 systemctl stop goveebttemplogger.service
 systemctl disable goveebttemplogger.service
 


### PR DESCRIPTION
Runs the system service as a non-root user.

The postinst script in the Debian package installer will create the user and modify the permissions of the log directory as necessary.

The postinst script will use the gvh-organizelogs utility program to backup and rename any log files with the old filename format that started with gvh507x_ instead of the newer format of gvh-.