### PR TITLE
Redefining stat64 as stat in non-glibc compile environments (e.g., musl)

### DIFF
--- a/goveebttemplogger.cpp
+++ b/goveebttemplogger.cpp
@@ -103,6 +103,9 @@ typedef struct {
 } __attribute__((packed)) bdaddr_t;
 #endif // !bdaddr_t
 #include "wimiso8601.h"
+#if !defined(__GLIBC__)
+    #define stat64 stat
+#endif
 /////////////////////////////////////////////////////////////////////////////
 #if __has_include("goveebttemplogger-version.h")
 #include "goveebttemplogger-version.h"

--- a/gvh-organizelogs.cpp
+++ b/gvh-organizelogs.cpp
@@ -53,6 +53,9 @@
 #include <unistd.h> // For close()
 #include <utime.h>
 #include "wimiso8601.h"
+#if !defined(__GLIBC__)
+    #define stat64 stat
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 #if __has_include("goveebttemplogger-version.h")


### PR DESCRIPTION
If I try to compile on Alpine Linux, I get the following  errors:
```
/root/GoveeBTTempLogger/goveebttemplogger.cpp: In function 'bool ValidateDirectory(const std::filesystem::__cxx11::path&)':
/root/GoveeBTTempLogger/goveebttemplogger.cpp:924:23: error: aggregate 'ValidateDirectory(const std::filesystem::__cxx11::path&)::stat64 StatBuffer' has incomplete type and cannot be defined
  924 |         struct stat64 StatBuffer;
      |                       ^~~~~~~~~~
/root/GoveeBTTempLogger/goveebttemplogger.cpp:925:59: error: invalid use of incomplete type 'struct ValidateDirectory(const std::filesystem::__cxx11::path&)::stat64'
  925 |         if (0 == stat64(DirectoryName.c_str(), &StatBuffer))
      |                                                           ^
...
```

The usage of `stat64` breaks the build on non-glibc linux systems (e.g., musl that Alpine uses), as those systems do not support LFS64. For non-GCC, one should use `stat` instead of `stat64`.

My proposed solution is simply redefining `stat64` as `stat` if using non-GLIBC environment.

With that change, application compiles and runs on Alpine Linux (and presumably other musl environments).

Closes #83 (Cannot compile on Alpine Linux)