### PR TITLE
Gvh organizelogs mergelogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 add_compile_definitions(_BLUEZ_HCI_)
 
 project (GoveeBTTempLogger
-    VERSION 3.20260308.0
+    VERSION 3.20260317.0
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 add_compile_definitions(_BLUEZ_HCI_)
 
 project (GoveeBTTempLogger
-    VERSION 3.20260212.0
+    VERSION 3.20260308.0
     DESCRIPTION "Listen and log Govee Thermometer Bluetooth Low Energy Advertisments via BlueZ and DBus"
     HOMEPAGE_URL https://github.com/wcbonner/GoveeBTTempLogger
 )

--- a/GoveeBTTempLogger.sln
+++ b/GoveeBTTempLogger.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.10.35013.160
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11527.330 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GoveeBTTempLogger", "GoveeBTTempLogger.vcxproj", "{87469263-8DEA-4963-9E12-C4F20FA83479}"
 EndProject
@@ -9,6 +9,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
 		Debug|x86 = Debug|x86
+		Debug-GVH-OrganizeLogs|ARM64 = Debug-GVH-OrganizeLogs|ARM64
+		Debug-GVH-OrganizeLogs|x86 = Debug-GVH-OrganizeLogs|x86
 		Release|ARM64 = Release|ARM64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -19,6 +21,12 @@ Global
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug|x86.ActiveCfg = Debug|x86
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug|x86.Build.0 = Debug|x86
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug|x86.Deploy.0 = Debug|x86
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|ARM64.ActiveCfg = Debug-GVH-OrganizeLogs|ARM64
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|ARM64.Build.0 = Debug-GVH-OrganizeLogs|ARM64
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|ARM64.Deploy.0 = Debug-GVH-OrganizeLogs|ARM64
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|x86.ActiveCfg = Debug-GVH-OrganizeLogs|x86
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|x86.Build.0 = Debug-GVH-OrganizeLogs|x86
+		{87469263-8DEA-4963-9E12-C4F20FA83479}.Debug-GVH-OrganizeLogs|x86.Deploy.0 = Debug-GVH-OrganizeLogs|x86
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Release|ARM64.ActiveCfg = Release|ARM64
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Release|ARM64.Build.0 = Release|ARM64
 		{87469263-8DEA-4963-9E12-C4F20FA83479}.Release|ARM64.Deploy.0 = Release|ARM64

--- a/GoveeBTTempLogger.vcxproj
+++ b/GoveeBTTempLogger.vcxproj
@@ -1,6 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug-GVH-OrganizeLogs|ARM">
+      <Configuration>Debug-GVH-OrganizeLogs</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-GVH-OrganizeLogs|ARM64">
+      <Configuration>Debug-GVH-OrganizeLogs</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-GVH-OrganizeLogs|x64">
+      <Configuration>Debug-GVH-OrganizeLogs</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug-GVH-OrganizeLogs|x86">
+      <Configuration>Debug-GVH-OrganizeLogs</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
       <Platform>ARM</Platform>
@@ -48,10 +64,17 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WSL2_1_0</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x86'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WSL2_1_0</PlatformToolset>
   </PropertyGroup>
@@ -60,6 +83,10 @@
     <PlatformToolset>WSL2_1_0</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WSL_1_0</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>WSL_1_0</PlatformToolset>
   </PropertyGroup>
@@ -72,6 +99,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />
@@ -81,20 +111,30 @@
     <IncludePath>
     </IncludePath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x86'">
+    <IncludePath />
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <IncludePath>
     </IncludePath>
   </PropertyGroup>
   <ItemGroup>
-    <ClCompile Include="goveebttemplogger.cpp" />
+    <ClCompile Include="goveebttemplogger.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="gvh-organizelogs.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x86'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x86'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="uuid.c" />
@@ -129,6 +169,33 @@
     <ClInclude Include="wimiso8601.h" />
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Link>
+      <LibraryDependencies>bluetooth</LibraryDependencies>
+      <AdditionalOptions>
+      </AdditionalOptions>
+    </Link>
+    <ClCompile />
+    <ClCompile />
+    <PreBuildEvent />
+    <RemotePostBuildEvent />
+    <RemotePreBuildEvent>
+      <Command>
+      </Command>
+    </RemotePreBuildEvent>
+    <RemotePostBuildEvent>
+      <Command>sudo setcap 'cap_net_raw,cap_net_admin+eip' $(RemoteTargetPath)</Command>
+    </RemotePostBuildEvent>
+    <ClCompile />
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG;DISPLAY_BT_SERVICE_DETAILS</PreprocessorDefinitions>
+      <CppLanguageStandard>c++17</CppLanguageStandard>
+    </ClCompile>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM'">
     <Link>
       <LibraryDependencies>bluetooth</LibraryDependencies>
       <AdditionalOptions>
@@ -194,6 +261,20 @@
       <Command>sudo setcap 'cap_net_raw,cap_net_admin+eip' $(RemoteTargetPath)</Command>
     </RemotePostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|ARM64'">
+    <Link>
+      <LibraryDependencies>bluetooth;dbus-1</LibraryDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG;_BLUEZ_HCI_</PreprocessorDefinitions>
+      <CppLanguageStandard>c++17</CppLanguageStandard>
+      <AdditionalIncludeDirectories>%(ClCompile.AdditionalIncludeDirectories);/usr/include/dbus-1.0;/usr/lib/aarch64-linux-gnu/dbus-1.0/include/</AdditionalIncludeDirectories>
+    </ClCompile>
+    <RemotePostBuildEvent>
+      <Command>sudo setcap 'cap_net_raw,cap_net_admin+eip' $(RemoteTargetPath)</Command>
+    </RemotePostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <LibraryDependencies>bluetooth;dbus-1</LibraryDependencies>
@@ -218,6 +299,16 @@
       <CppLanguageStandard>c++17</CppLanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x64'">
+    <Link>
+      <LibraryDependencies>bluetooth</LibraryDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG</PreprocessorDefinitions>
+      <CppLanguageStandard>c++17</CppLanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <LibraryDependencies>bluetooth</LibraryDependencies>
@@ -228,6 +319,17 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Link>
+      <LibraryDependencies>bluetooth;dbus-1</LibraryDependencies>
+    </Link>
+    <ClCompile />
+    <ClCompile>
+      <PreprocessorDefinitions>DEBUG</PreprocessorDefinitions>
+      <CppLanguageStandard>c++17</CppLanguageStandard>
+      <AdditionalIncludeDirectories>$(StlIncludeDirectories);%(ClCompile.AdditionalIncludeDirectories);/usr/include/dbus-1.0;/usr/lib/x86_64-linux-gnu/dbus-1.0/include</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-GVH-OrganizeLogs|x86'">
     <Link>
       <LibraryDependencies>bluetooth;dbus-1</LibraryDependencies>
     </Link>

--- a/README.md
+++ b/README.md
@@ -198,22 +198,40 @@ sudo apt install bluetooth bluez libbluetooth-dev -y
  * -H (--HCI) Prefer deprecated BlueZ HCI interface over modern DBus communication
  * -p (--passive) Bluetooth LE Passive Scanning
 
- ## Log File Format
+## Overview of gvh-organizelogs
+### Introduction to gvh-organizelogs
+gvh-organizelogs has existed as a separate program for some time. It was developed to streamline log files by internally sorting the data, eliminating exact duplicate lines, and removing unnecessary characters.
+### New Feature: Directory Merge Capability 2026-03-08
+The program is now being enhanced with a new feature: the ability to specify a directory containing data to merge into the primary log directory.
+### Merge Process Workflow
+The merging process involves loading each log file from the designated merge directory, sorting its contents, and then appending the sorted lines to the appropriate files in the main log directory. This assignment is based on the Bluetooth address and timestamp found in each data line from the merge file.
+```
+Usage: gvh-organizelogs [options]
+  GoveeBTTempLogOrganizer Version 3.20260308.0 Built on: Mar  8 2026 at 12:46:14
+  Options:
+    -h | --help          Print this message
+    -l | --log name      Logging Directory [""]
+    -f | --file name     Single log file to process []
+    -b | --backup name   Backup Directory [""]
+    -m | --merge name    Merge Directory [""]
+```
 
- The log file format has been stable for a long time as a simple tab-separated text file with a set number of columns: Date (UTC), Temperature (C), Humidity, Battery.
+## Log File Format
 
- With the addition of support for the meat thermometers multiple temperature readings, I've changed the format slightly in a way that should be backwards compatible with most programs reading existing logs. After the existing columns of Date, Temperature, Humidity, Battery I've added optional columns of Model, Temperature, Temperature, Temperature
+The log file format has been stable for a long time as a simple tab-separated text file with a set number of columns: Date (UTC), Temperature (C), Humidity, Battery.
+
+With the addition of support for the meat thermometers multiple temperature readings, I've changed the format slightly in a way that should be backwards compatible with most programs reading existing logs. After the existing columns of Date, Temperature, Humidity, Battery I've added optional columns of Model, Temperature, Temperature, Temperature
  
- ### Minor update 2023-04-03
- I changed the default log filename to start with `gvh-` instead of `gvh507x_`. The code will still read the old log files, and will rename the current months log file to the new format. I used the linux shell command `for f in gvh507x_*.txt; do sudo mv "${f}" "${f//gvh507x_/gvh-}"; done` in the log file directory to rename all of the old files to the new format on my machine.
+### Minor update 2023-04-03
+I changed the default log filename to start with `gvh-` instead of `gvh507x_`. The code will still read the old log files, and will rename the current months log file to the new format. I used the linux shell command `for f in gvh507x_*.txt; do sudo mv "${f}" "${f//gvh507x_/gvh-}"; done` in the log file directory to rename all of the old files to the new format on my machine.
 
- ## Bluetooth UUID details
-  * (UUID) 88EC (Name) Govee_H5074_C7A1
-  * (Name) GVH5075_AE36 (UUID) 88EC
-  * (Name) GVH5174_CC3D (UUID) 88EC
-  * (Name) GVH5177_3B10 (UUID) 88EC
-  * (UUID) 5182
-  * (UUID) 5183
+## Bluetooth UUID details
+* (UUID) 88EC (Name) Govee_H5074_C7A1
+* (Name) GVH5075_AE36 (UUID) 88EC
+* (Name) GVH5174_CC3D (UUID) 88EC
+* (Name) GVH5177_3B10 (UUID) 88EC
+* (UUID) 5182
+* (UUID) 5183
 
 The 5074, 5075, 5174, and 5177 units all broadcast a UUID of 88EC. Unfortunately, the 5074 does not include the UUID in the same advertisment as the temperatures. 
 

--- a/goveebttemplogger.cpp
+++ b/goveebttemplogger.cpp
@@ -951,7 +951,7 @@ void SignalHandlerSIGALRM(int signal)
 		std::cout << "[" << getTimeISO8601(true) << "] ***************** SIGALRM: Caught Alarm. *****************" << std::endl;
 }
 /////////////////////////////////////////////////////////////////////////////
-bool ValidateDirectory(const std::filesystem::path& DirectoryName)
+bool ValidateDirectory(const std::filesystem::path& DirectoryName, const bool bWriteable = true)
 {
 	bool rval = false;
 	// https://linux.die.net/man/2/stat
@@ -960,7 +960,11 @@ bool ValidateDirectory(const std::filesystem::path& DirectoryName)
 		if (S_ISDIR(StatBuffer.st_mode))
 		{
 			// https://linux.die.net/man/2/access
-			if (0 == access(DirectoryName.c_str(), R_OK | W_OK))
+			int mode = R_OK;
+			if (bWriteable)
+				mode |= W_OK;
+			// Check if the directory is readable and writeable
+			if (0 == access(DirectoryName.c_str(), mode))
 				rval = true;
 			else
 			{

--- a/gvh-organizelogs.cpp
+++ b/gvh-organizelogs.cpp
@@ -70,19 +70,20 @@ std::filesystem::path LogDirectory;
 std::filesystem::path MergeDirectory;
 std::filesystem::path BackupDirectory;
 /////////////////////////////////////////////////////////////////////////////
-bool ValidateDirectory(std::string& DirectoryName)
+bool ValidateDirectory(const std::filesystem::path& DirectoryName, const bool bWriteable = true)
 {
 	bool rval = false;
-	// I want to make sure the directory name does not end with a "/"
-	while ((!DirectoryName.empty()) && (DirectoryName.back() == '/'))
-		DirectoryName.pop_back();
 	// https://linux.die.net/man/2/stat
 	struct stat64 StatBuffer;
 	if (0 == stat64(DirectoryName.c_str(), &StatBuffer))
 		if (S_ISDIR(StatBuffer.st_mode))
 		{
 			// https://linux.die.net/man/2/access
-			if (0 == access(DirectoryName.c_str(), R_OK | W_OK))
+			int mode = R_OK;
+			if (bWriteable)
+				mode |= W_OK;
+			// Check if the directory is readable and writeable
+			if (0 == access(DirectoryName.c_str(), mode))
 				rval = true;
 			else
 			{
@@ -252,6 +253,7 @@ int main(int argc, char** argv)
 	for (;;)
 	{
 		std::string TempString;
+		std::filesystem::path TempPath;
 		int idx;
 		int c = getopt_long(argc, argv, short_options, long_options, &idx);
 		if (-1 == c)
@@ -265,19 +267,25 @@ int main(int argc, char** argv)
 			usage(argc, argv);
 			exit(EXIT_SUCCESS);
 		case 'l':
-			TempString = std::string(optarg);
-			if (ValidateDirectory(TempString))
-				LogDirectory = TempString;
+			TempPath = std::string(optarg);
+			while (TempPath.filename().empty() && (TempPath != TempPath.root_directory())) // This gets rid of the "/" on the end of the path
+				TempPath = TempPath.parent_path();
+			if (ValidateDirectory(TempPath))
+				LogDirectory = TempPath;
 			break;
 		case 'b':
-			TempString = std::string(optarg);
-			if (ValidateDirectory(TempString))
-				BackupDirectory = TempString;
+			TempPath = std::string(optarg);
+			while (TempPath.filename().empty() && (TempPath != TempPath.root_directory())) // This gets rid of the "/" on the end of the path
+				TempPath = TempPath.parent_path();
+			if (ValidateDirectory(TempPath))
+				BackupDirectory = TempPath;
 			break;
 		case 'm':
-			TempString = std::string(optarg);
-			if (ValidateDirectory(TempString))
-				MergeDirectory = TempString;
+			TempPath = std::string(optarg);
+			while (TempPath.filename().empty() && (TempPath != TempPath.root_directory())) // This gets rid of the "/" on the end of the path
+				TempPath = TempPath.parent_path();
+			if (ValidateDirectory(TempPath, false))
+				MergeDirectory = TempPath;
 			break;
 		default:
 			usage(argc, argv);
@@ -294,6 +302,7 @@ int main(int argc, char** argv)
 
 	if (!LogDirectory.empty() && !MergeDirectory.empty())
 	{
+		std::cout << "[" << getTimeISO8601() << "] Merging contents of: " << MergeDirectory << " into " << LogDirectory << std::endl;
 		// Merging contents of MergeDirectory into LogDirectory.
 		const std::regex LogFileRegex("(gvh507x_|gvh-)[[:xdigit:]]{12}-[[:digit:]]{4}-[[:digit:]]{2}.txt"); // 2024-10-01 Both old and new format recognized
 		std::deque<std::filesystem::path> files;
@@ -330,14 +339,14 @@ int main(int argc, char** argv)
 							DataLines.push_back(TheLine);
 							count++;
 						}
-						std::cout << " (" << count << " lines)";
+						std::cout << " (" << count << " lines)" << std::endl;
 						TheFile.close();
 
 						// Sort all Data
 						sort(DataLines.begin(), DataLines.end());
 						// Distribute Data to appropriate new Log Files
 						std::ofstream LogFile;
-						time_t TheTime(0), LastTime(0);
+						time_t TheTime(0);
 						int LastYear(0), LastMonth(0);
 						std::filesystem::path LastFileName;
 						std::string LastLine;
@@ -359,13 +368,6 @@ int main(int argc, char** argv)
 											{
 												std::cout << " (" << count << " lines)" << std::endl;
 												LogFile.close();
-												if (!LastFileName.empty())
-												{
-													struct utimbuf ut;
-													ut.actime = LastTime;
-													ut.modtime = LastTime;
-													utime(LastFileName.c_str(), &ut);
-												}
 											}
 											LastFileName = GenerateLogFileName(TheBlueToothAddress, TheTime);
 											LogFile.open(LastFileName, std::ios_base::out | std::ios_base::app);
@@ -373,7 +375,6 @@ int main(int argc, char** argv)
 											count = 0;
 										}
 										LogFile << *DataLines.begin() << std::endl;
-										LastTime = TheTime;
 										count++;
 									}
 									LastLine = *DataLines.begin();
@@ -383,13 +384,6 @@ int main(int argc, char** argv)
 						}
 						std::cout << " (" << count << " lines)" << std::endl;
 						LogFile.close();
-						if (!LastFileName.empty())
-						{
-							struct utimbuf ut;
-							ut.actime = LastTime;
-							ut.modtime = LastTime;
-							utime(LastFileName.c_str(), &ut);
-						}
 						files.pop_front();
 					}
 				}
@@ -400,6 +394,9 @@ int main(int argc, char** argv)
 		usage(argc, argv);
 	else
 	{
+		std::cout << "[" << getTimeISO8601() << "] Organizing contents of: " << LogDirectory << std::endl;
+		std::cout << "[" << getTimeISO8601() << "]  Using BackupDirectory: " << BackupDirectory << std::endl;
+
 		const std::regex LogFileRegex("(gvh507x_|gvh-)[[:xdigit:]]{12}-[[:digit:]]{4}-[[:digit:]]{2}.txt"); // 2024-10-01 Both old and new format recognized
 		std::deque<std::filesystem::path> files;
 		for (auto const& dir_entry : std::filesystem::directory_iterator{ LogDirectory })

--- a/gvh-organizelogs.cpp
+++ b/gvh-organizelogs.cpp
@@ -67,6 +67,7 @@
 /////////////////////////////////////////////////////////////////////////////
 static const std::string ProgramVersionString("GoveeBTTempLogOrganizer Version " GoveeBTTempLogger_VERSION " Built on: " __DATE__ " at " __TIME__);
 std::filesystem::path LogDirectory;
+std::filesystem::path MergeDirectory;
 std::filesystem::path BackupDirectory;
 /////////////////////////////////////////////////////////////////////////////
 bool ValidateDirectory(std::string& DirectoryName)
@@ -231,14 +232,16 @@ static void usage(int argc, char** argv)
 	std::cout << "    -l | --log name      Logging Directory [" << LogDirectory << "]" << std::endl;
 	std::cout << "    -f | --file name     Single log file to process [" <<  "]" << std::endl;
 	std::cout << "    -b | --backup name   Backup Directory [" << BackupDirectory << "]" << std::endl;
+	std::cout << "    -m | --merge name    Merge Directory [" << MergeDirectory << "]" << std::endl;
 	std::cout << std::endl;
 }
-static const char short_options[] = "hl:f:b:";
+static const char short_options[] = "hl:f:b:m:";
 static const struct option long_options[] = {
 		{ "help",   no_argument,       NULL, 'h' },
 		{ "log",    required_argument, NULL, 'l' },
 		{ "file",   required_argument, NULL, 'f' },
 		{ "backup", required_argument, NULL, 'b' },
+		{ "merge",  required_argument, NULL, 'm' },
 		{ 0, 0, 0, 0 }
 };
 /////////////////////////////////////////////////////////////////////////////
@@ -271,6 +274,11 @@ int main(int argc, char** argv)
 			if (ValidateDirectory(TempString))
 				BackupDirectory = TempString;
 			break;
+		case 'm':
+			TempString = std::string(optarg);
+			if (ValidateDirectory(TempString))
+				MergeDirectory = TempString;
+			break;
 		default:
 			usage(argc, argv);
 			exit(EXIT_FAILURE);
@@ -283,7 +291,112 @@ int main(int argc, char** argv)
 	std::locale mylocale("");   // get global locale
 	std::cout.imbue(mylocale);  // imbue global locale
 	///////////////////////////////////////////////////////////////////////////////////////////////
-	if (LogDirectory.empty() || BackupDirectory.empty())
+
+	if (!LogDirectory.empty() && !MergeDirectory.empty())
+	{
+		// Merging contents of MergeDirectory into LogDirectory.
+		const std::regex LogFileRegex("(gvh507x_|gvh-)[[:xdigit:]]{12}-[[:digit:]]{4}-[[:digit:]]{2}.txt"); // 2024-10-01 Both old and new format recognized
+		std::deque<std::filesystem::path> files;
+		for (auto const& dir_entry : std::filesystem::directory_iterator{ MergeDirectory })
+			if (dir_entry.is_regular_file())
+				if (std::regex_match(dir_entry.path().filename().string(), LogFileRegex))
+					files.push_back(dir_entry);
+		if (!files.empty())
+		{
+			sort(files.begin(), files.end());
+			bdaddr_t LastBlueToothAddress({ 0 });
+			while (!files.empty())
+			{
+				std::filesystem::path FQFileName(*files.begin());
+				std::ifstream TheFile(FQFileName);
+				if (TheFile.is_open())
+				{
+					std::deque<std::string> DataLines;
+					std::cout << "[" << getTimeISO8601() << "] Reading: " << FQFileName;
+					const std::regex ModifiedBluetoothAddressRegex("[[:xdigit:]]{12}");
+					std::smatch BluetoothAddressInFilename;
+					std::string Stem(FQFileName.stem());
+					if (std::regex_search(Stem, BluetoothAddressInFilename, ModifiedBluetoothAddressRegex))
+					{
+						bdaddr_t TheBlueToothAddress(string2ba(BluetoothAddressInFilename.str()));
+						int count(0);
+						// Read All Data From Existing Log, removing nulls if possible
+						std::string TheLine;
+						while (std::getline(TheFile, TheLine))
+						{
+							// erase any nulls from the data. these are occasionally in the log file when the platform crashed during a write to the logfile.
+							for (auto pos = TheLine.find('\000'); pos != std::string::npos; pos = TheLine.find('\000'))
+								TheLine.erase(pos);
+							DataLines.push_back(TheLine);
+							count++;
+						}
+						std::cout << " (" << count << " lines)";
+						TheFile.close();
+
+						// Sort all Data
+						sort(DataLines.begin(), DataLines.end());
+						// Distribute Data to appropriate new Log Files
+						std::ofstream LogFile;
+						time_t TheTime(0), LastTime(0);
+						int LastYear(0), LastMonth(0);
+						std::filesystem::path LastFileName;
+						std::string LastLine;
+						while (!DataLines.empty())
+						{
+							if (DataLines.begin()->length() > 18)	// line is longer than an ISO8601 String
+							{
+								if (0 != LastLine.compare(*DataLines.begin()))	// line is unique
+								{
+									TheTime = ISO8601totime(*DataLines.begin());
+									struct tm UTC;
+									if (nullptr != gmtime_r(&TheTime, &UTC))
+									{
+										if ((UTC.tm_year != LastYear) || (UTC.tm_mon != LastMonth))
+										{
+											LastYear = UTC.tm_year;
+											LastMonth = UTC.tm_mon;
+											if (LogFile.is_open())
+											{
+												std::cout << " (" << count << " lines)" << std::endl;
+												LogFile.close();
+												if (!LastFileName.empty())
+												{
+													struct utimbuf ut;
+													ut.actime = LastTime;
+													ut.modtime = LastTime;
+													utime(LastFileName.c_str(), &ut);
+												}
+											}
+											LastFileName = GenerateLogFileName(TheBlueToothAddress, TheTime);
+											LogFile.open(LastFileName, std::ios_base::out | std::ios_base::app);
+											std::cout << "[" << getTimeISO8601() << "] Writing: " << LastFileName;
+											count = 0;
+										}
+										LogFile << *DataLines.begin() << std::endl;
+										LastTime = TheTime;
+										count++;
+									}
+									LastLine = *DataLines.begin();
+								}
+							}
+							DataLines.pop_front();
+						}
+						std::cout << " (" << count << " lines)" << std::endl;
+						LogFile.close();
+						if (!LastFileName.empty())
+						{
+							struct utimbuf ut;
+							ut.actime = LastTime;
+							ut.modtime = LastTime;
+							utime(LastFileName.c_str(), &ut);
+						}
+						files.pop_front();
+					}
+				}
+			}
+		}
+	}
+	else if (LogDirectory.empty() || BackupDirectory.empty())
 		usage(argc, argv);
 	else
 	{


### PR DESCRIPTION
Add feature to gvh-organizelogs of merging a log directory into the existing log directory. Interprets filenames to bluetooth addresses in the standard method and appends the contents of the directory to be merged into the existing log files. 

I needed this because my primary acquisition machine is not running, and I'm recording data on a secondary machine but expect to want to merge the data back together when the primary machine is powered back on. 

I created a special build target in Visual Studio allowing me to easily switch between debugging the main program and debugging gvh-organizelogs